### PR TITLE
Fix plan order to accept language versioned names too

### DIFF
--- a/Kauko/xml/xml_exporter.py
+++ b/Kauko/xml/xml_exporter.py
@@ -588,10 +588,12 @@ class XMLExporter:
             plan_order = self.add_lud_core_element(entry, PLAN_ORDER)
 
         if "name" in entry and entry["name"]:
-            # TODO: use this once name is proper jsonb field
-            # add_language_string_elements(plan_order, NAME_INSIDE_SPLAN, entry["name"])
-            element = SubElement(plan_order, NAME_INSIDE_SPLAN, {"xml:lang": "fin"})
-            element.text = entry["name"]
+            # TODO: remove this once zoning element name is proper jsonb field too
+            if isinstance(entry["name"], str):
+                element = SubElement(plan_order, NAME_INSIDE_SPLAN, {"xml:lang": "fin"})
+                element.text = entry["name"]
+            else:
+                add_language_string_elements(plan_order, NAME_INSIDE_SPLAN, entry["name"])
 
         for value_type, values in values.items():
             for value in values:


### PR DESCRIPTION
Fixing zoning element name field broke other plan order name fields. This hot fix should accept both, until zoning element name field also gets proper language versions.