### PR TITLE
Hotfix plan order groups

### DIFF
--- a/Kauko/xml/xml_exporter.py
+++ b/Kauko/xml/xml_exporter.py
@@ -996,7 +996,7 @@ class XMLExporter:
 
         # 10) Regulation groups may only be added after all regulations have been added. They refer
         # to existing regulations.
-        self.add_regulation_groups(zoning_element_regulation_groups, regulations_by_group)
+        self.add_regulation_groups(regulation_groups, regulations_by_group)
 
         # 11) Fetch and create all commentaries
         commentaries = get_plan_commentaries(plan_data["local_id"], self.db, self.schema)

--- a/Kauko/xml/xml_exporter.py
+++ b/Kauko/xml/xml_exporter.py
@@ -588,10 +588,12 @@ class XMLExporter:
             plan_order = self.add_lud_core_element(entry, PLAN_ORDER)
 
         if "name" in entry and entry["name"]:
-            # TODO: use this once name is proper jsonb field
-            # add_language_string_elements(plan_order, NAME_INSIDE_SPLAN, entry["name"])
-            element = SubElement(plan_order, NAME_INSIDE_SPLAN, {"xml:lang": "fin"})
-            element.text = entry["name"]
+            # TODO: remove this once zoning element name is proper jsonb field too
+            if isinstance(entry["name"], str):
+                element = SubElement(plan_order, NAME_INSIDE_SPLAN, {"xml:lang": "fin"})
+                element.text = entry["name"]
+            else:
+                add_language_string_elements(plan_order, NAME_INSIDE_SPLAN, entry["name"])
 
         for value_type, values in values.items():
             for value in values:


### PR DESCRIPTION
There was an error in importing plan order groups, only zoning element groups were imported. Now all plan order groups are imported.