### PR TITLE
Fixes for XML export in validation test case

### DIFF
--- a/Kauko/xml/xml_exporter.py
+++ b/Kauko/xml/xml_exporter.py
@@ -1074,15 +1074,13 @@ class XMLExporter:
             planned_space_guidances.keys(),
             detail_line_guidances.keys(),
         )
-        guidances = {
-            guidance_id: {
-                **plan_guidances[guidance_id],
-                **zoning_element_guidances[guidance_id],
-                **planned_space_guidances[guidance_id],
-                **detail_line_guidances[guidance_id],
-            }
-            for guidance_id in guidance_ids
-        }
+        guidances = {}
+        for guidance_id in guidance_ids:
+            guidances[guidance_id] = {}
+            guidances[guidance_id].update(plan_guidances.get(guidance_id, {}))
+            guidances[guidance_id].update(zoning_element_guidances.get(guidance_id, {}))
+            guidances[guidance_id].update(planned_space_guidances.get(guidance_id, {}))
+            guidances[guidance_id].update(detail_line_guidances.get(guidance_id, {}))
         LOGGER.info("got guidances:")
         LOGGER.info(guidances)
         self.add_regulations(regulations)

--- a/Kauko/xml/xml_exporter.py
+++ b/Kauko/xml/xml_exporter.py
@@ -992,14 +992,12 @@ class XMLExporter:
             detail_line_regulation_groups.keys(),
         )
         # regulation groups by group id and target id:
-        regulation_groups = {
-            group_id: {
-                **(zoning_element_regulation_groups[group_id]),
-                **(planned_space_regulation_groups[group_id]),
-                **(detail_line_regulation_groups[group_id]),
-            }
-            for group_id in group_ids
-        }
+        regulation_groups = {}
+        for group_id in group_ids:
+            regulation_groups[group_id] = {}
+            regulation_groups[group_id].update(zoning_element_regulation_groups.get(group_id, {}))
+            regulation_groups[group_id].update(planned_space_regulation_groups.get(group_id, {}))
+            regulation_groups[group_id].update(detail_line_regulation_groups.get(group_id, {}))
         LOGGER.info("got groups:")
         LOGGER.info(regulation_groups)
         # get all regulations in groups:
@@ -1060,18 +1058,14 @@ class XMLExporter:
             group_regulations.keys(),
         )
         # regulations by regulation id and target id:
-        regulations = {
-            regulation_id: {
-                **(plan_regulations[regulation_id]),
-                **(zoning_element_regulations[regulation_id]),
-                **(planned_space_regulations[regulation_id]),
-                **(detail_line_regulations[regulation_id]),
-                None: group_regulations.get(
-                    regulation_id, None
-                ),  # group regulations have no target
-            }
-            for regulation_id in regulation_ids
-        }
+        regulations = {}
+        for regulation_id in regulation_ids:
+            regulations[regulation_id] = {}
+            regulations[regulation_id].update(plan_regulations.get(regulation_id, {}))
+            regulations[regulation_id].update(zoning_element_regulations.get(regulation_id, {}))
+            regulations[regulation_id].update(planned_space_regulations.get(regulation_id, {}))
+            regulations[regulation_id].update(detail_line_regulations.get(regulation_id, {}))
+            regulations[regulation_id].update(group_regulations.get(regulation_id, {}))
         LOGGER.info("got regulations:")
         LOGGER.info(regulations)
         guidance_ids = set().union(

--- a/Kauko/xml/xml_exporter.py
+++ b/Kauko/xml/xml_exporter.py
@@ -273,14 +273,17 @@ def add_value_element(parent: Element, value_type: str, value: DictRow) -> Eleme
         unit_element = SubElement(type_element, UNIT_OF_MEASURE)
         unit_element.text = value["unit_of_measure"]
     elif value_type == "numeric_range":
-        MINIMUM_VALUE = SPLAN_NS + ":minimumValue"
-        MAXIMUM_VALUE = SPLAN_NS + ":maximumValue"
-        minimum_element = SubElement(type_element, MINIMUM_VALUE)
-        minimum_element.text = str(value["minimum_value"])
-        maximum_element = SubElement(type_element, MAXIMUM_VALUE)
-        maximum_element.text = str(value["maximum_value"])
-        unit_element = SubElement(type_element, UNIT_OF_MEASURE)
-        unit_element.text = value["unit_of_measure"]
+        if value["minimum_value"] is not None:
+            MINIMUM_VALUE = SPLAN_NS + ":minimumValue"
+            minimum_element = SubElement(type_element, MINIMUM_VALUE)
+            minimum_element.text = str(value["minimum_value"])
+        if value["maximum_value"] is not None:
+            MAXIMUM_VALUE = SPLAN_NS + ":maximumValue"
+            maximum_element = SubElement(type_element, MAXIMUM_VALUE)
+            maximum_element.text = str(value["maximum_value"])
+        if value["unit_of_measure"] is not None:
+            unit_element = SubElement(type_element, UNIT_OF_MEASURE)
+            unit_element.text = value["unit_of_measure"]
     elif value_type == "time_instant_value":
         value_element = SubElement(type_element, VALUE)
         add_time_position(value_element, value["value"])

--- a/Kauko/xml/xml_exporter.py
+++ b/Kauko/xml/xml_exporter.py
@@ -1065,7 +1065,7 @@ class XMLExporter:
             regulations[regulation_id].update(zoning_element_regulations.get(regulation_id, {}))
             regulations[regulation_id].update(planned_space_regulations.get(regulation_id, {}))
             regulations[regulation_id].update(detail_line_regulations.get(regulation_id, {}))
-            regulations[regulation_id].update(group_regulations.get(regulation_id, {}))
+            regulations[regulation_id][None] = group_regulations.get(regulation_id, None)
         LOGGER.info("got regulations:")
         LOGGER.info(regulations)
         guidance_ids = set().union(


### PR DESCRIPTION
Fixing some issues in the export functionality.

- handling cases in which all kind of elements are not included
- using correct code lists for master plans
- fixed handling numeric ranges

The code outside the export functionality is not touched. The export functionality produces valid XML for the test cases.