### PR TITLE
KAAVA-61: plan_interaction_event table changes

### DIFF
--- a/Kauko.DbUp/Scripts/002_insert_code_list_data.sql
+++ b/Kauko.DbUp/Scripts/002_insert_code_list_data.sql
@@ -1366,6 +1366,14 @@ CREATE SEQUENCE code_lists.validity_type_identifier_seq
     NO MAXVALUE
     CACHE 1;
 
+
+--
+-- Name: validity_type_identifier_seq; Type: SEQUENCE OWNED BY; Schema: code_lists; Owner: -
+--
+
+ALTER SEQUENCE code_lists.validity_type_identifier_seq OWNED BY code_lists.validity_type.identifier;
+
+
 --
 -- Name: data_type; Type: TABLE; Schema: code_lists; Owner: -
 --
@@ -1378,10 +1386,46 @@ CREATE TABLE code_lists.data_type (
 
 
 --
--- Name: validity_type_identifier_seq; Type: SEQUENCE OWNED BY; Schema: code_lists; Owner: -
+-- Name: plan_interaction_event_type; Type: TABLE; Schema: code_lists; Owner: -
 --
 
-ALTER SEQUENCE code_lists.validity_type_identifier_seq OWNED BY code_lists.validity_type.identifier;
+CREATE TABLE code_lists.plan_interaction_event_type (
+    id integer PRIMARY KEY,
+    codevalue character varying(3) NOT NULL,
+    uri character varying(255) NOT NULL,
+    preflabel_fi character varying NOT NULL,
+    preflabel_sv character varying,
+    preflabel_en character varying,
+    CONSTRAINT plan_interaction_event_type_codevalue_key UNIQUE (codevalue),
+    CONSTRAINT plan_interaction_event_type_uri UNIQUE (uri)
+);
+
+
+--
+-- Name: plan_interaction_event_type_id_seq; Type: SEQUENCE; Schema: code_lists; Owner: -
+--
+
+CREATE SEQUENCE code_lists.plan_interaction_event_type_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: plan_interaction_event_type_id_seq; Type: SEQUENCE OWNED BY; Schema: code_lists; Owner: -
+--
+
+ALTER SEQUENCE code_lists.plan_interaction_event_type_id_seq OWNED BY code_lists.plan_interaction_event_type.id;
+
+
+--
+-- Name: plan_interaction_event_type id; Type: DEFAULT; Schema: code_lists; Owner: -
+--
+
+ALTER TABLE ONLY code_lists.plan_interaction_event_type ALTER COLUMN id SET DEFAULT nextval('code_lists.plan_interaction_event_type_id_seq'::regclass);
 
 
 --
@@ -4070,6 +4114,21 @@ INSERT INTO code_lists.data_type (value, description) VALUES (11, 'Code');
 INSERT INTO code_lists.data_type (value, description) VALUES (12, 'Identifier');
 INSERT INTO code_lists.data_type (value, description) VALUES (13, 'SpotElevation');
 
+
+--
+-- Data for Name: plan_interaction_event_type; Type: TABLE DATA; Schema: code_lists; Owner: -
+--
+
+INSERT INTO code_lists.plan_interaction_event_type VALUES (1, '01', 'http://uri.suomi.fi/codelist/rytj/RY_KaavanVuorovaikutustapahtumanLaji/code/01', 'Nähtävilläolo', 'Tillgänglighet', 'Presentation to the public');
+INSERT INTO code_lists.plan_interaction_event_type VALUES (2, '02', 'http://uri.suomi.fi/codelist/rytj/RY_KaavanVuorovaikutustapahtumanLaji/code/02', 'Lausuntopyyntö', 'Begäran om utlåtande', 'Request for opinions');
+INSERT INTO code_lists.plan_interaction_event_type VALUES (3, '03', 'http://uri.suomi.fi/codelist/rytj/RY_KaavanVuorovaikutustapahtumanLaji/code/03', 'Vuorovaikutustilaisuus', 'Interaktiv tillställning', 'Interaction event');
+INSERT INTO code_lists.plan_interaction_event_type VALUES (4, '04', 'http://uri.suomi.fi/codelist/rytj/RY_KaavanVuorovaikutustapahtumanLaji/code/04', 'Tiedonkeruu', 'Informationsinsamling', 'Data collection');
+INSERT INTO code_lists.plan_interaction_event_type VALUES (5, '05', 'http://uri.suomi.fi/codelist/rytj/RY_KaavanVuorovaikutustapahtumanLaji/code/05', 'Neuvottelu', 'Förhandling', 'Negotiation');
+INSERT INTO code_lists.plan_interaction_event_type VALUES (6, '06', 'http://uri.suomi.fi/codelist/rytj/RY_KaavanVuorovaikutustapahtumanLaji/code/06', 'Sähköinen osallistuminen', 'Deltagande elektroniskt', 'Electronic participation');
+INSERT INTO code_lists.plan_interaction_event_type VALUES (7, '07', 'http://uri.suomi.fi/codelist/rytj/RY_KaavanVuorovaikutustapahtumanLaji/code/07', 'Muutoksenhaku', 'Ändringsansökan', 'Appeal');
+INSERT INTO code_lists.plan_interaction_event_type VALUES (8, '08', 'http://uri.suomi.fi/codelist/rytj/RY_KaavanVuorovaikutustapahtumanLaji/code/08', 'Muu vuorovaikutustapahtuma', 'Annan interaktiv händelse', 'Other interaction event');
+
+
 --
 -- Name: bindingness_kind_id_seq; Type: SEQUENCE SET; Schema: code_lists; Owner: -
 --
@@ -4355,6 +4414,13 @@ SELECT pg_catalog.setval('code_lists.spatial_plan_lifecycle_status_id_seq', 15, 
 --
 
 SELECT pg_catalog.setval('code_lists.validity_type_identifier_seq', 1, false);
+
+
+--
+-- Name: plan_interaction_event_type_id_seq; Type: SEQUENCE SET; Schema: code_lists; Owner: -
+--
+
+SELECT pg_catalog.setval('code_lists.plan_interaction_event_type_id_seq', 8, true);
 
 
 --

--- a/Kauko.DbUp/Scripts/008_create_code_list_triggers.sql
+++ b/Kauko.DbUp/Scripts/008_create_code_list_triggers.sql
@@ -121,3 +121,10 @@ CREATE TRIGGER upsert_url_spatial_plan_kind BEFORE INSERT OR UPDATE ON code_list
 --
 
 CREATE TRIGGER upsert_url_spatial_plan_lifecycle_status BEFORE INSERT OR UPDATE ON code_lists.spatial_plan_lifecycle_status FOR EACH ROW EXECUTE FUNCTION code_lists.code_url_trigger('http://uri.suomi.fi/codelist/rytj/RY_KaavanElinkaaritila/code/');
+
+
+--
+-- Name: plan_interaction_event_type upsert_plan_interaction_event_type; Type: TRIGGER; Schema: code_lists; Owner: -
+--
+
+CREATE TRIGGER upsert_plan_interaction_event_type BEFORE INSERT OR UPDATE ON code_lists.plan_interaction_event_type FOR EACH ROW EXECUTE FUNCTION code_lists.code_url_trigger('http://uri.suomi.fi/codelist/rytj/RY_KaavanVuorovaikutustapahtumanLaji/code/');

--- a/Kauko.DbUp/Scripts/011_create_ryhti_tables.sql
+++ b/Kauko.DbUp/Scripts/011_create_ryhti_tables.sql
@@ -61,6 +61,22 @@ CREATE TABLE IF NOT EXISTS $SCHEMANAME$.plan_interaction_event (
     CONSTRAINT plan_interaction_event_description_check CHECK (check_ryhti_language(description))
 );
 
+-- Table: $SCHEMANAME$.spatial_plan_interaction_event
+
+CREATE TABLE IF NOT EXISTS $SCHEMANAME$.spatial_plan_interaction_event (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    fk_plan_interaction_event TEXT NOT NULL,
+    fk_spatial_plan TEXT NOT NULL,
+    CONSTRAINT spatial_plan_interaction_event_fk_plan_interaction_event_fkey FOREIGN KEY (fk_plan_interaction_event)
+        REFERENCES $SCHEMANAME$.plan_interaction_event (local_id) MATCH SIMPLE
+        ON UPDATE CASCADE
+        ON DELETE RESTRICT,
+    CONSTRAINT spatial_plan_interaction_event_fk_spatial_plan_fkey FOREIGN KEY (fk_spatial_plan)
+        REFERENCES $SCHEMANAME$.spatial_plan (local_id) MATCH SIMPLE
+        ON UPDATE CASCADE
+        ON DELETE RESTRICT
+);
+
 
 -- Table: $SCHEMANAME$.localized_text_values
 

--- a/Kauko.DbUp/Scripts/011_create_ryhti_tables.sql
+++ b/Kauko.DbUp/Scripts/011_create_ryhti_tables.sql
@@ -57,6 +57,7 @@ CREATE TABLE IF NOT EXISTS $SCHEMANAME$.plan_interaction_event (
     additional_information_link TEXT,
     cancelled BOOLEAN,
     related_documents JSONB, -- TODO: linkitys document-tauluun
+    CONSTRAINT plan_interaction_event_local_id_key UNIQUE (local_id),
     CONSTRAINT plan_interaction_event_name_check CHECK (check_ryhti_language(name)),
     CONSTRAINT plan_interaction_event_description_check CHECK (check_ryhti_language(description))
 );

--- a/Kauko.DbUp/Scripts/011_create_ryhti_tables.sql
+++ b/Kauko.DbUp/Scripts/011_create_ryhti_tables.sql
@@ -42,10 +42,11 @@ CREATE TABLE IF NOT EXISTS $SCHEMANAME$.identifier_value (
 );
 
 
--- Table: $SCHEMANAME$.interaction_event
+-- Table: $SCHEMANAME$.plan_interaction_event
 
-CREATE TABLE IF NOT EXISTS $SCHEMANAME$.interaction_event (
-    id UUID PRIMARY KEY,
+CREATE TABLE IF NOT EXISTS $SCHEMANAME$.plan_interaction_event (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    local_id TEXT NOT NULL DEFAULT uuid_generate_v4(),
     interaction_event_type VARCHAR(255) NOT NULL,
     event_time JSONB,
     name JSONB,
@@ -54,8 +55,8 @@ CREATE TABLE IF NOT EXISTS $SCHEMANAME$.interaction_event (
     additional_information_link TEXT,
     cancelled BOOLEAN,
     related_documents JSONB,
-    CONSTRAINT interaction_event_name_check CHECK (check_ryhti_language(name)),
-    CONSTRAINT interaction_event_description_check CHECK (check_ryhti_language(description))
+    CONSTRAINT plan_interaction_event_name_check CHECK (check_ryhti_language(name)),
+    CONSTRAINT plan_interaction_event_description_check CHECK (check_ryhti_language(description))
 );
 
 

--- a/Kauko.DbUp/Scripts/011_create_ryhti_tables.sql
+++ b/Kauko.DbUp/Scripts/011_create_ryhti_tables.sql
@@ -47,7 +47,7 @@ CREATE TABLE IF NOT EXISTS $SCHEMANAME$.identifier_value (
 CREATE TABLE IF NOT EXISTS $SCHEMANAME$.plan_interaction_event (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     local_id TEXT NOT NULL DEFAULT uuid_generate_v4(),
-    interaction_event_type VARCHAR(255) NOT NULL,
+    interaction_event_type VARCHAR(3) NOT NULL,
     event_time_begin timestamp with time zone NOT NULL,
     event_time_end timestamp with time zone,
     name JSONB,
@@ -58,6 +58,10 @@ CREATE TABLE IF NOT EXISTS $SCHEMANAME$.plan_interaction_event (
     cancelled BOOLEAN,
     related_documents JSONB, -- TODO: linkitys document-tauluun
     CONSTRAINT plan_interaction_event_local_id_key UNIQUE (local_id),
+    CONSTRAINT plan_interaction_event_interaction_event_type_fkey FOREIGN KEY (interaction_event_type)
+        REFERENCES code_lists.plan_interaction_event_type (codevalue) MATCH SIMPLE
+        ON UPDATE CASCADE
+        ON DELETE RESTRICT,
     CONSTRAINT plan_interaction_event_name_check CHECK (check_ryhti_language(name)),
     CONSTRAINT plan_interaction_event_description_check CHECK (check_ryhti_language(description))
 );

--- a/Kauko.DbUp/Scripts/011_create_ryhti_tables.sql
+++ b/Kauko.DbUp/Scripts/011_create_ryhti_tables.sql
@@ -48,13 +48,15 @@ CREATE TABLE IF NOT EXISTS $SCHEMANAME$.plan_interaction_event (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     local_id TEXT NOT NULL DEFAULT uuid_generate_v4(),
     interaction_event_type VARCHAR(255) NOT NULL,
-    event_time JSONB,
+    event_time_begin timestamp with time zone NOT NULL,
+    event_time_end timestamp with time zone,
     name JSONB,
     description JSONB,
-    location JSONB,
+    epsg character(9) NOT NULL DEFAULT 'EPSG:$PROJECTSRID$'::bpchar,
+    geom geometry(MultiPolygon,$PROJECTSRID$) NOT NULL,
     additional_information_link TEXT,
     cancelled BOOLEAN,
-    related_documents JSONB,
+    related_documents JSONB, -- TODO: linkitys document-tauluun
     CONSTRAINT plan_interaction_event_name_check CHECK (check_ryhti_language(name)),
     CONSTRAINT plan_interaction_event_description_check CHECK (check_ryhti_language(description))
 );


### PR DESCRIPTION
Add column local_id to table plan_interaction_event
Split event_time column to event_time_begin and event_time_end
Split location column to espg and geom
Add unique constraint to plan_interaction_event.local_id
Add a new link table: spatial_plan_interaction_event
Create and populate a new code table: plan_interaction_event_type
Create a trigger for the new code table
