### PR TITLE
KAAVA-72: Fixes for interaction event tables

### DIFF
--- a/Kauko.DbUp/Scripts/011_create_ryhti_tables.sql
+++ b/Kauko.DbUp/Scripts/011_create_ryhti_tables.sql
@@ -52,8 +52,7 @@ CREATE TABLE IF NOT EXISTS $SCHEMANAME$.plan_interaction_event (
     event_time_end timestamp with time zone,
     name JSONB,
     description JSONB,
-    epsg character(9) NOT NULL DEFAULT 'EPSG:$PROJECTSRID$'::bpchar,
-    geom geometry(MultiPolygon,$PROJECTSRID$) NOT NULL,
+    geom geometry(MultiPolygon,$PROJECTSRID$),
     additional_information_link TEXT,
     cancelled BOOLEAN,
     related_documents JSONB, -- TODO: linkitys document-tauluun
@@ -75,11 +74,13 @@ CREATE TABLE IF NOT EXISTS $SCHEMANAME$.spatial_plan_interaction_event (
     CONSTRAINT spatial_plan_interaction_event_fk_plan_interaction_event_fkey FOREIGN KEY (fk_plan_interaction_event)
         REFERENCES $SCHEMANAME$.plan_interaction_event (local_id) MATCH SIMPLE
         ON UPDATE CASCADE
-        ON DELETE RESTRICT,
+        ON DELETE RESTRICT
+        DEFERRABLE INITIALLY DEFERRED,
     CONSTRAINT spatial_plan_interaction_event_fk_spatial_plan_fkey FOREIGN KEY (fk_spatial_plan)
         REFERENCES $SCHEMANAME$.spatial_plan (local_id) MATCH SIMPLE
         ON UPDATE CASCADE
         ON DELETE RESTRICT
+        DEFERRABLE INITIALLY DEFERRED
 );
 
 


### PR DESCRIPTION
Remove column epsg from table plan_interaction_event
Set column geom nullable in table plan_interaction_event
Add DEFERRABLE INITIALLY DEFERRED for foreign keys in table spatial_plan_interaction_event