### PR TITLE
KAAVA-164 Changes to value tables

### DIFF
--- a/Kauko.DbUp/Scripts/005_create_initial_tables.sql
+++ b/Kauko.DbUp/Scripts/005_create_initial_tables.sql
@@ -904,30 +904,6 @@ CREATE TABLE IF NOT EXISTS $SCHEMANAME$.plan_regulation_group
 );
 
 
--- Table: $SCHEMANAME$.spatial_plan_plan_regulation_group
-
--- DROP TABLE IF EXISTS $SCHEMANAME$.spatial_plan_plan_regulation_group;
-
-CREATE TABLE IF NOT EXISTS $SCHEMANAME$.spatial_plan_plan_regulation_group
-(
-    id integer NOT NULL GENERATED ALWAYS AS IDENTITY,
-    fk_spatial_plan TEXT NOT NULL,
-    fk_plan_regulation_group TEXT NOT NULL,
-    CONSTRAINT spatial_plan_plan_regulation_group_pkey PRIMARY KEY (id),
-    CONSTRAINT spatial_plan_plan_regulation_group_key UNIQUE (fk_spatial_plan, fk_plan_regulation_group),
-    CONSTRAINT spatial_plan_plan_regulation_group_fk_spatial_plan_fkey FOREIGN KEY (fk_spatial_plan)
-        REFERENCES $SCHEMANAME$.spatial_plan (local_id) MATCH SIMPLE
-        ON UPDATE CASCADE
-        ON DELETE CASCADE
-        DEFERRABLE INITIALLY DEFERRED,
-    CONSTRAINT spatial_plan_plan_reg_group_fk_plan_regulation_group_fkey FOREIGN KEY (fk_plan_regulation_group)
-        REFERENCES $SCHEMANAME$.plan_regulation_group (local_id) MATCH SIMPLE
-        ON UPDATE CASCADE
-        ON DELETE CASCADE
-        DEFERRABLE INITIALLY DEFERRED
-);
-
-
 -- Table: $SCHEMANAME$.plan_regulation_group_regulation
 
 -- DROP TABLE IF EXISTS $SCHEMANAME$.plan_regulation_group_regulation;

--- a/Kauko.DbUp/Scripts/040_value_table_changes.sql
+++ b/Kauko.DbUp/Scripts/040_value_table_changes.sql
@@ -1,0 +1,209 @@
+-- New value table: indentifier_value
+---------------------------------------
+
+-- Table: $SCHEMANAME$.indentifier_value 
+
+-- DROP TABLE IF EXISTS $SCHEMANAME$.indentifier_value;
+
+CREATE TABLE IF NOT EXISTS $SCHEMANAME$.indentifier_value
+(
+    id integer NOT NULL GENERATED ALWAYS AS IDENTITY,
+    indentifier_value_uuid uuid NOT NULL DEFAULT uuid_generate_v4(),
+    value text NOT NULL,
+    CONSTRAINT indentifier_value_pkey PRIMARY KEY (id),
+    CONSTRAINT indentifier_value_indentifier_value_uuid_key UNIQUE (indentifier_value_uuid)
+);
+
+-- Add foreign keys
+
+ALTER TABLE $SCHEMANAME$.plan_regulation
+    ADD fk_indentifier_value uuid,
+    ADD CONSTRAINT plan_regulation_fk_indentifier_value FOREIGN KEY (fk_indentifier_value)
+    REFERENCES $SCHEMANAME$.indentifier_value(indentifier_value_uuid)
+        ON DELETE CASCADE
+        ON UPDATE CASCADE
+        DEFERRABLE INITIALLY DEFERRED;
+
+ALTER TABLE $SCHEMANAME$.supplementary_information
+    ADD fk_indentifier_value uuid,
+    ADD CONSTRAINT supplementary_information_fk_indentifier_value FOREIGN KEY (fk_indentifier_value)
+    REFERENCES $SCHEMANAME$.indentifier_value(indentifier_value_uuid)
+        ON DELETE CASCADE
+        ON UPDATE CASCADE
+        DEFERRABLE INITIALLY DEFERRED;
+
+
+-- Drop check constraints
+---------------------------
+
+ALTER TABLE $SCHEMANAME$.plan_regulation
+    DROP CONSTRAINT IF EXISTS ensure_one_fk;
+
+ALTER TABLE $SCHEMANAME$.supplementary_information
+    DROP CONSTRAINT IF EXISTS ensure_one_fk;
+
+
+-- Alter text_value table's value column
+-------------------------------------------
+
+ALTER TABLE $SCHEMANAME$.text_value
+    DROP CONSTRAINT IF EXISTS text_value_value_check,
+    DROP COLUMN IF EXISTS value,
+    ADD value text;
+
+
+-- New value table: localized_text_value
+------------------------------------------
+
+-- Table: $SCHEMANAME$.localized_text_value 
+
+-- DROP TABLE IF EXISTS $SCHEMANAME$.localized_text_value;
+
+CREATE TABLE IF NOT EXISTS $SCHEMANAME$.localized_text_value (
+	id int4 GENERATED ALWAYS AS IDENTITY,
+	localized_text_value_uuid uuid DEFAULT uuid_generate_v4() NOT NULL,
+	value jsonb NOT NULL,
+	syntax text NULL,
+	CONSTRAINT localized_text_value_pkey PRIMARY KEY (id),
+	CONSTRAINT localized_text_value_localized_text_value_uuid_key UNIQUE (localized_text_value_uuid),
+	CONSTRAINT localized_text_value_value_check CHECK (check_ryhti_language(value))
+);
+
+-- Add foreign keys
+
+ALTER TABLE $SCHEMANAME$.plan_regulation
+    ADD fk_localized_text_value uuid,
+    ADD CONSTRAINT plan_regulation_fk_localized_text_value FOREIGN KEY (fk_localized_text_value)
+    REFERENCES $SCHEMANAME$.localized_text_value(localized_text_value_uuid)
+        ON DELETE CASCADE
+        ON UPDATE CASCADE
+        DEFERRABLE INITIALLY DEFERRED;
+
+ALTER TABLE $SCHEMANAME$.supplementary_information
+    ADD fk_localized_text_value uuid,
+    ADD CONSTRAINT supplementary_information_fk_localized_text_value FOREIGN KEY (fk_localized_text_value)
+    REFERENCES $SCHEMANAME$.localized_text_value(localized_text_value_uuid)
+        ON DELETE CASCADE
+        ON UPDATE CASCADE
+        DEFERRABLE INITIALLY DEFERRED;
+
+
+-- Modify time_period_value table
+-----------------------------------
+
+ALTER TABLE $SCHEMANAME$.time_period_value
+    DROP COLUMN IF EXISTS value;
+
+
+-- New value table: time_period_date_only_value
+------------------------------------------
+
+-- Table: $SCHEMANAME$.time_period_date_only_value 
+
+-- DROP TABLE IF EXISTS $SCHEMANAME$.time_period_date_only_value;
+
+CREATE TABLE IF NOT EXISTS $SCHEMANAME$.time_period_date_only_value (
+	id int4 GENERATED ALWAYS AS IDENTITY,
+	time_period_date_only_value_uuid uuid DEFAULT uuid_generate_v4() NOT NULL,
+	value date NOT NULL,
+	CONSTRAINT time_period_date_only_value_pkey PRIMARY KEY (id),
+	CONSTRAINT tpdo_value_time_period_date_only_value_uuid_key UNIQUE (time_period_date_only_value_uuid)
+);
+
+-- Add foreign keys
+
+ALTER TABLE $SCHEMANAME$.plan_regulation
+    ADD fk_time_period_date_only_value uuid,
+    ADD CONSTRAINT plan_regulation_fk_time_period_date_only_value FOREIGN KEY (fk_time_period_date_only_value)
+    REFERENCES $SCHEMANAME$.time_period_date_only_value(time_period_date_only_value_uuid)
+        ON DELETE CASCADE
+        ON UPDATE CASCADE
+        DEFERRABLE INITIALLY DEFERRED;
+
+ALTER TABLE $SCHEMANAME$.supplementary_information
+    ADD fk_time_period_date_only_value uuid,
+    ADD CONSTRAINT supplementary_information_fk_time_period_date_only_value FOREIGN KEY (fk_time_period_date_only_value)
+    REFERENCES $SCHEMANAME$.time_period_date_only_value(time_period_date_only_value_uuid)
+        ON DELETE CASCADE
+        ON UPDATE CASCADE
+        DEFERRABLE INITIALLY DEFERRED;
+
+
+-- Drop tables no longer needed
+---------------------------------
+
+-- Drop foreign keys and columns from plan_regulation and supplementary_information
+
+ALTER TABLE $SCHEMANAME$.plan_regulation
+    DROP CONSTRAINT IF EXISTS plan_regulation_fk_elevation_position_value,
+    DROP CONSTRAINT IF EXISTS plan_regulation_fk_elevation_range_value,
+    DROP CONSTRAINT IF EXISTS plan_regulation_fk_geometry_area_value,
+    DROP CONSTRAINT IF EXISTS plan_regulation_fk_geometry_line_value,
+    DROP CONSTRAINT IF EXISTS plan_regulation_fk_geometry_point_value,
+    DROP CONSTRAINT IF EXISTS plan_regulation_fk_time_instant_value,
+    DROP CONSTRAINT IF EXISTS plan_regulation_fk_time_period_value,
+    DROP COLUMN IF EXISTS fk_elevation_position_value,
+    DROP COLUMN IF EXISTS fk_elevation_range_value,
+    DROP COLUMN IF EXISTS fk_geometry_area_value,
+    DROP COLUMN IF EXISTS fk_geometry_line_value,
+    DROP COLUMN IF EXISTS fk_geometry_point_value,
+    DROP COLUMN IF EXISTS fk_time_instant_value,
+    DROP COLUMN IF EXISTS fk_time_period_value;
+
+ALTER TABLE $SCHEMANAME$.supplementary_information
+    DROP CONSTRAINT IF EXISTS supplementary_information_fk_elevation_position_value,
+    DROP CONSTRAINT IF EXISTS supplementary_information_fk_elevation_range_value,
+    DROP CONSTRAINT IF EXISTS supplementary_information_fk_geometry_area_value,
+    DROP CONSTRAINT IF EXISTS supplementary_information_fk_geometry_line_value,
+    DROP CONSTRAINT IF EXISTS supplementary_information_fk_geometry_point_value,
+    DROP CONSTRAINT IF EXISTS supplementary_information_fk_time_instant_value,
+    DROP CONSTRAINT IF EXISTS supplementary_information_fk_time_period_value,
+    DROP COLUMN IF EXISTS fk_elevation_position_value,
+    DROP COLUMN IF EXISTS fk_elevation_range_value,
+    DROP COLUMN IF EXISTS fk_geometry_area_value,
+    DROP COLUMN IF EXISTS fk_geometry_line_value,
+    DROP COLUMN IF EXISTS fk_geometry_point_value,
+    DROP COLUMN IF EXISTS fk_time_instant_value,
+    DROP COLUMN IF EXISTS fk_time_period_value;
+
+-- Drop tables
+
+DROP TABLE IF EXISTS $SCHEMANAME$.elevation_position_value;
+DROP TABLE IF EXISTS $SCHEMANAME$.elevation_range_value;
+DROP TABLE IF EXISTS $SCHEMANAME$.geometry_area_value;
+DROP TABLE IF EXISTS $SCHEMANAME$.geometry_line_value;
+DROP TABLE IF EXISTS $SCHEMANAME$.geometry_point_value;
+DROP TABLE IF EXISTS $SCHEMANAME$.time_instant_value;
+DROP TABLE IF EXISTS $SCHEMANAME$.time_period_value;
+
+
+-- Add renewed check constraints
+--------------------------------
+
+ALTER TABLE $SCHEMANAME$.plan_regulation
+    ADD CONSTRAINT ensure_one_fk
+        CHECK (
+            num_nonnulls(
+                fk_code_value,
+                fk_numeric_value,
+                fk_numeric_range,
+                fk_text_value,
+                fk_indentifier_value,
+                fk_localized_text_value,
+                fk_time_period_date_only_value
+            ) = ANY (ARRAY[0, 1])
+        );
+
+ALTER TABLE $SCHEMANAME$.supplementary_information
+    ADD CONSTRAINT ensure_one_fk
+        CHECK (
+            num_nonnulls(
+                fk_code_value,
+                fk_numeric_value,
+                fk_numeric_range,
+                fk_text_value,
+                fk_indentifier_value,
+                fk_localized_text_value,
+                fk_time_period_date_only_value
+            ) = ANY (ARRAY[0, 1])
+        );

--- a/Kauko.DbUp/Scripts/040_value_table_changes.sql
+++ b/Kauko.DbUp/Scripts/040_value_table_changes.sql
@@ -96,7 +96,8 @@ ALTER TABLE $SCHEMANAME$.time_period_value
     DROP COLUMN IF EXISTS time_period_from,
     DROP COLUMN IF EXISTS time_period_to,
     ADD time_period_begin timestamp with time zone NOT NULL,
-    ADD time_period_end timestamp with time zone;
+    ADD time_period_end timestamp with time zone,
+    ADD CONSTRAINT time_period_value_time_period_check CHECK (time_period_end IS NULL OR time_period_end >= time_period_begin);
 
 
 -- New value table: time_period_date_only_value
@@ -112,7 +113,8 @@ CREATE TABLE IF NOT EXISTS $SCHEMANAME$.time_period_date_only_value (
 	time_period_date_only_begin date NOT NULL,
     time_period_date_only_end date,
 	CONSTRAINT time_period_date_only_value_pkey PRIMARY KEY (id),
-	CONSTRAINT tpdo_value_time_period_date_only_value_uuid_key UNIQUE (time_period_date_only_value_uuid)
+	CONSTRAINT tpdo_value_time_period_date_only_value_uuid_key UNIQUE (time_period_date_only_value_uuid),
+    CONSTRAINT time_period_date_only_value_time_period_date_only_check CHECK (time_period_date_only_end IS NULL OR time_period_date_only_end >= time_period_date_only_begin)
 );
 
 -- Add foreign keys

--- a/Kauko.DbUp/Scripts/040_value_table_changes.sql
+++ b/Kauko.DbUp/Scripts/040_value_table_changes.sql
@@ -92,7 +92,11 @@ ALTER TABLE $SCHEMANAME$.supplementary_information
 -----------------------------------
 
 ALTER TABLE $SCHEMANAME$.time_period_value
-    DROP COLUMN IF EXISTS value;
+    DROP COLUMN IF EXISTS value,
+    DROP COLUMN IF EXISTS time_period_from,
+    DROP COLUMN IF EXISTS time_period_to,
+    ADD time_period_begin timestamp with time zone NOT NULL,
+    ADD time_period_end timestamp with time zone;
 
 
 -- New value table: time_period_date_only_value
@@ -105,7 +109,8 @@ ALTER TABLE $SCHEMANAME$.time_period_value
 CREATE TABLE IF NOT EXISTS $SCHEMANAME$.time_period_date_only_value (
 	id int4 GENERATED ALWAYS AS IDENTITY,
 	time_period_date_only_value_uuid uuid DEFAULT uuid_generate_v4() NOT NULL,
-	value date NOT NULL,
+	time_period_date_only_begin date NOT NULL,
+    time_period_date_only_end date,
 	CONSTRAINT time_period_date_only_value_pkey PRIMARY KEY (id),
 	CONSTRAINT tpdo_value_time_period_date_only_value_uuid_key UNIQUE (time_period_date_only_value_uuid)
 );
@@ -141,14 +146,12 @@ ALTER TABLE $SCHEMANAME$.plan_regulation
     DROP CONSTRAINT IF EXISTS plan_regulation_fk_geometry_line_value,
     DROP CONSTRAINT IF EXISTS plan_regulation_fk_geometry_point_value,
     DROP CONSTRAINT IF EXISTS plan_regulation_fk_time_instant_value,
-    DROP CONSTRAINT IF EXISTS plan_regulation_fk_time_period_value,
     DROP COLUMN IF EXISTS fk_elevation_position_value,
     DROP COLUMN IF EXISTS fk_elevation_range_value,
     DROP COLUMN IF EXISTS fk_geometry_area_value,
     DROP COLUMN IF EXISTS fk_geometry_line_value,
     DROP COLUMN IF EXISTS fk_geometry_point_value,
-    DROP COLUMN IF EXISTS fk_time_instant_value,
-    DROP COLUMN IF EXISTS fk_time_period_value;
+    DROP COLUMN IF EXISTS fk_time_instant_value;
 
 ALTER TABLE $SCHEMANAME$.supplementary_information
     DROP CONSTRAINT IF EXISTS supplementary_information_fk_elevation_position_value,
@@ -157,14 +160,12 @@ ALTER TABLE $SCHEMANAME$.supplementary_information
     DROP CONSTRAINT IF EXISTS supplementary_information_fk_geometry_line_value,
     DROP CONSTRAINT IF EXISTS supplementary_information_fk_geometry_point_value,
     DROP CONSTRAINT IF EXISTS supplementary_information_fk_time_instant_value,
-    DROP CONSTRAINT IF EXISTS supplementary_information_fk_time_period_value,
     DROP COLUMN IF EXISTS fk_elevation_position_value,
     DROP COLUMN IF EXISTS fk_elevation_range_value,
     DROP COLUMN IF EXISTS fk_geometry_area_value,
     DROP COLUMN IF EXISTS fk_geometry_line_value,
     DROP COLUMN IF EXISTS fk_geometry_point_value,
-    DROP COLUMN IF EXISTS fk_time_instant_value,
-    DROP COLUMN IF EXISTS fk_time_period_value;
+    DROP COLUMN IF EXISTS fk_time_instant_value;
 
 -- Drop tables
 
@@ -174,7 +175,7 @@ DROP TABLE IF EXISTS $SCHEMANAME$.geometry_area_value;
 DROP TABLE IF EXISTS $SCHEMANAME$.geometry_line_value;
 DROP TABLE IF EXISTS $SCHEMANAME$.geometry_point_value;
 DROP TABLE IF EXISTS $SCHEMANAME$.time_instant_value;
-DROP TABLE IF EXISTS $SCHEMANAME$.time_period_value;
+DROP TABLE IF EXISTS $SCHEMANAME$.time_period_date_only;
 
 
 -- Add renewed check constraints
@@ -190,6 +191,7 @@ ALTER TABLE $SCHEMANAME$.plan_regulation
                 fk_text_value,
                 fk_indentifier_value,
                 fk_localized_text_value,
+                fk_time_period_value,
                 fk_time_period_date_only_value
             ) = ANY (ARRAY[0, 1])
         );
@@ -204,6 +206,7 @@ ALTER TABLE $SCHEMANAME$.supplementary_information
                 fk_text_value,
                 fk_indentifier_value,
                 fk_localized_text_value,
+                fk_time_period_value,
                 fk_time_period_date_only_value
             ) = ANY (ARRAY[0, 1])
         );

--- a/Kauko.DbUp/Scripts/views/kauko_views_create.sql
+++ b/Kauko.DbUp/Scripts/views/kauko_views_create.sql
@@ -347,7 +347,7 @@ FROM
 --  VIEW VIEW_RYHTI_PLAN_REGULATION_ADDITIONAL_INFORMATION - Kaavamääräyksen lisätiedot
 --
 --  2025-04-16 TKu
---  2025-11-06 TKu Columns removed:
+--  2025-12-04 TKu Columns removed:
 --                   - elevation_position_value
 --                   - elevation_range_minimum_value
 --                   - elevation_range_maximum_value
@@ -359,7 +359,10 @@ FROM
 --                 Columns added:
 --                   - indentifier_value
 --                   - localized_text_value
---                   - time_period_date_only_value
+--                   - time_period_begin
+--                   - time_period_end
+--                   - time_period_date_only_begin
+--                   - time_period_date_only_end
 ------------------------------------------------------------------------------------------
 
 CREATE OR REPLACE VIEW $SCHEMANAME$.view_ryhti_plan_regulation_additional_information AS
@@ -374,7 +377,10 @@ SELECT
     IV.value AS indentifier_value,
     TV.value AS text_value,
     LTV.value AS localized_text_value,
-    TPDOV.value AS time_period_date_only_value
+    TPV.time_period_begin AS time_period_begin,
+    TPV.time_period_end AS time_period_end,
+    TPDOV.time_period_date_only_begin AS time_period_date_only_begin,
+    TPDOV.time_period_date_only_end AS time_period_date_only_end
 FROM
     $SCHEMANAME$.supplementary_information SI
 JOIN code_lists.detail_plan_addition_information_kind DPAIK ON DPAIK.codevalue = SI.type
@@ -385,6 +391,7 @@ LEFT JOIN $SCHEMANAME$.numeric_range NR ON NR.numeric_range_uuid = SI.fk_numeric
 LEFT JOIN $SCHEMANAME$.indentifier_value IV ON IV.indentifier_value_uuid = SI.fk_indentifier_value
 LEFT JOIN $SCHEMANAME$.text_value TV ON TV.text_value_uuid = SI.fk_text_value
 LEFT JOIN $SCHEMANAME$.localized_text_value LTV ON LTV.localized_text_value_uuid = SI.fk_localized_text_value
+LEFT JOIN $SCHEMANAME$.time_period_value TPV ON TPV.time_period_uuid = SI.fk_time_period_value
 LEFT JOIN $SCHEMANAME$.time_period_date_only_value TPDOV ON TPDOV.time_period_date_only_value_uuid = SI.fk_time_period_date_only_value;
 
 

--- a/Kauko.DbUp/Scripts/views/kauko_views_create.sql
+++ b/Kauko.DbUp/Scripts/views/kauko_views_create.sql
@@ -347,6 +347,19 @@ FROM
 --  VIEW VIEW_RYHTI_PLAN_REGULATION_ADDITIONAL_INFORMATION - Kaavamääräyksen lisätiedot
 --
 --  2025-04-16 TKu
+--  2025-11-06 TKu Columns removed:
+--                   - elevation_position_value
+--                   - elevation_range_minimum_value
+--                   - elevation_range_maximum_value
+--                   - geometry_area_value
+--                   - geometry_line_value
+--                   - geometry_point_value
+--                   - time_instant_value
+--                   - time_period_value
+--                 Columns added:
+--                   - indentifier_value
+--                   - localized_text_value
+--                   - time_period_date_only_value
 ------------------------------------------------------------------------------------------
 
 CREATE OR REPLACE VIEW $SCHEMANAME$.view_ryhti_plan_regulation_additional_information AS
@@ -355,33 +368,24 @@ SELECT
     SI.local_id AS additional_information_key,
     DPAIK.uri AS type,
     CV.value AS code_value,
-    EPV.value AS elevation_position_value,
-    ERV.minimum_value AS elevation_range_minimum_value,
-    ERV.maximum_value AS elevation_range_maximum_value,
-    GAV.value AS geometry_area_value,
-    GLV.value AS geometry_line_value,
-    GPV.value AS geometry_point_value,
     NV.value AS numeric_value,
     NR.minimum_value AS numeric_range_minimum_value,
     NR.maximum_value AS numeric_range_maximum_value,
+    IV.value AS indentifier_value,
     TV.value AS text_value,
-    TIV.value AS time_instant_value,
-    TPV.value AS time_period_value
+    LTV.value AS localized_text_value,
+    TPDOV.value AS time_period_date_only_value
 FROM
     $SCHEMANAME$.supplementary_information SI
 JOIN code_lists.detail_plan_addition_information_kind DPAIK ON DPAIK.codevalue = SI.type
 JOIN $SCHEMANAME$.plan_regulation_supplementary_information PRSI ON PRSI.fk_supplementary_information = SI.local_id
 LEFT JOIN $SCHEMANAME$.code_value CV ON CV.code_value_uuid = SI.fk_code_value
-LEFT JOIN $SCHEMANAME$.elevation_position_value EPV ON EPV.elevation_position_value_uuid = SI.fk_elevation_position_value
-LEFT JOIN $SCHEMANAME$.elevation_range_value ERV ON ERV.elevation_range_value_uuid = SI.fk_elevation_range_value
-LEFT JOIN $SCHEMANAME$.geometry_area_value GAV ON GAV.geometry_area_value_uuid = SI.fk_geometry_area_value
-LEFT JOIN $SCHEMANAME$.geometry_line_value GLV ON GLV.geometry_line_value_uuid = SI.fk_geometry_line_value
-LEFT JOIN $SCHEMANAME$.geometry_point_value GPV ON GPV.geometry_point_value_uuid = SI.fk_geometry_point_value
 LEFT JOIN $SCHEMANAME$.numeric_value NV ON NV.numeric_value_uuid = SI.fk_numeric_value
 LEFT JOIN $SCHEMANAME$.numeric_range NR ON NR.numeric_range_uuid = SI.fk_numeric_range
+LEFT JOIN $SCHEMANAME$.indentifier_value IV ON IV.indentifier_value_uuid = SI.fk_indentifier_value
 LEFT JOIN $SCHEMANAME$.text_value TV ON TV.text_value_uuid = SI.fk_text_value
-LEFT JOIN $SCHEMANAME$.time_instant_value TIV ON TIV.time_instant_uuid = SI.fk_time_instant_value
-LEFT JOIN $SCHEMANAME$.time_period_value TPV ON TPV.time_period_uuid = SI.fk_time_period_value;
+LEFT JOIN $SCHEMANAME$.localized_text_value LTV ON LTV.localized_text_value_uuid = SI.fk_localized_text_value
+LEFT JOIN $SCHEMANAME$.time_period_date_only_value TPDOV ON TPDOV.time_period_date_only_value_uuid = SI.fk_time_period_date_only_value;
 
 
 -- View: $SCHEMANAME$.view_ryhti_plan_attachment_document


### PR DESCRIPTION
Drop value tables not needed.
Add new value tables.
Some changes to other value tables.
Fix foreign keys, constraints and views.
Remove table spatial_plan_plan_regulation_group from script 005 as it is created in 011 with correct column names.