### PR TITLE
feature/KAAVA-212-trigger-cleanup

### DIFF
--- a/Kauko.DbUp/Scripts/051_remove_and_disable_obsolete_triggers.sql
+++ b/Kauko.DbUp/Scripts/051_remove_and_disable_obsolete_triggers.sql
@@ -1,0 +1,66 @@
+-- KAAVA-212: Remove obsolete triggers and disable geometry relations triggers
+-- Validity and geometry validation triggers are no longer needed since plan data
+-- now comes from Ryhti GeoJSON. Geometry relations triggers are disabled (not dropped)
+-- so they can be re-enabled for QGIS manual drawing workflows.
+
+-- ============================================================================
+-- SECTION 1: Drop obsolete validity triggers (update_validity, inherit_validity)
+-- ============================================================================
+
+-- update_validity triggers (7 tables)
+DROP TRIGGER IF EXISTS update_validity ON $SCHEMANAME$.describing_line;
+DROP TRIGGER IF EXISTS update_validity ON $SCHEMANAME$.describing_text;
+DROP TRIGGER IF EXISTS update_validity ON $SCHEMANAME$.spatial_plan;
+DROP TRIGGER IF EXISTS update_validity ON $SCHEMANAME$.planned_space;
+DROP TRIGGER IF EXISTS update_validity ON $SCHEMANAME$.planning_detail_line;
+DROP TRIGGER IF EXISTS update_validity ON $SCHEMANAME$.planning_detail_point;
+DROP TRIGGER IF EXISTS update_validity ON $SCHEMANAME$.zoning_element;
+
+-- inherit_validity triggers (3 tables)
+DROP TRIGGER IF EXISTS inherit_validity ON $SCHEMANAME$.spatial_plan;
+DROP TRIGGER IF EXISTS inherit_validity ON $SCHEMANAME$.planned_space;
+DROP TRIGGER IF EXISTS inherit_validity ON $SCHEMANAME$.zoning_element;
+
+-- ============================================================================
+-- SECTION 2: Drop obsolete geometry validation triggers
+-- ============================================================================
+
+-- validate_*_geom triggers (7 tables)
+DROP TRIGGER IF EXISTS validate_describing_line_geom ON $SCHEMANAME$.describing_line;
+DROP TRIGGER IF EXISTS validate_describing_text_geom ON $SCHEMANAME$.describing_text;
+DROP TRIGGER IF EXISTS validate_spatial_plan_geom ON $SCHEMANAME$.spatial_plan;
+DROP TRIGGER IF EXISTS validate_planned_space_geom ON $SCHEMANAME$.planned_space;
+DROP TRIGGER IF EXISTS validate_planning_detail_line_geom ON $SCHEMANAME$.planning_detail_line;
+DROP TRIGGER IF EXISTS validate_planning_detail_point_geom ON $SCHEMANAME$.planning_detail_point;
+DROP TRIGGER IF EXISTS validate_zoning_element_geom ON $SCHEMANAME$.zoning_element;
+
+-- validate_*_topology triggers (3 tables)
+DROP TRIGGER IF EXISTS validate_spatial_plan_topology ON $SCHEMANAME$.spatial_plan;
+DROP TRIGGER IF EXISTS validate_planned_space_topology ON $SCHEMANAME$.planned_space;
+DROP TRIGGER IF EXISTS validate_zoning_element_topology ON $SCHEMANAME$.zoning_element;
+
+-- ============================================================================
+-- SECTION 3: Disable geometry relations triggers (kept for QGIS manual drawing)
+-- ============================================================================
+
+-- delete_geom_relations triggers (7 tables)
+ALTER TABLE $SCHEMANAME$.describing_line DISABLE TRIGGER delete_geom_relations;
+ALTER TABLE $SCHEMANAME$.describing_text DISABLE TRIGGER delete_geom_relations;
+ALTER TABLE $SCHEMANAME$.spatial_plan DISABLE TRIGGER delete_geom_relations;
+ALTER TABLE $SCHEMANAME$.planned_space DISABLE TRIGGER delete_geom_relations;
+ALTER TABLE $SCHEMANAME$.planning_detail_line DISABLE TRIGGER delete_geom_relations;
+ALTER TABLE $SCHEMANAME$.planning_detail_point DISABLE TRIGGER delete_geom_relations;
+ALTER TABLE $SCHEMANAME$.zoning_element DISABLE TRIGGER delete_geom_relations;
+
+-- geom_relations triggers (7 tables)
+ALTER TABLE $SCHEMANAME$.describing_line DISABLE TRIGGER geom_relations;
+ALTER TABLE $SCHEMANAME$.describing_text DISABLE TRIGGER geom_relations;
+ALTER TABLE $SCHEMANAME$.spatial_plan DISABLE TRIGGER geom_relations;
+ALTER TABLE $SCHEMANAME$.planned_space DISABLE TRIGGER geom_relations;
+ALTER TABLE $SCHEMANAME$.planning_detail_line DISABLE TRIGGER geom_relations;
+ALTER TABLE $SCHEMANAME$.planning_detail_point DISABLE TRIGGER geom_relations;
+ALTER TABLE $SCHEMANAME$.zoning_element DISABLE TRIGGER geom_relations;
+
+-- create_or_update_spatial_plan triggers (2 tables)
+ALTER TABLE $SCHEMANAME$.spatial_plan_main DISABLE TRIGGER create_or_update_spatial_plan;
+ALTER TABLE $SCHEMANAME$.spatial_plan DISABLE TRIGGER create_or_update_spatial_plan;


### PR DESCRIPTION
# feat(KAAVA-212): Remove obsolete triggers and disable geometry relations

## Summary

Adds migration script `051_remove_and_disable_obsolete_triggers.sql` that cleans up database triggers no longer needed after the transition to Ryhti GeoJSON imports.

## Changes

**Drops 20 obsolete triggers** (validity + geometry validation):
- `update_validity` on 7 tables (describing_line, describing_text, spatial_plan, planned_space, planning_detail_line, planning_detail_point, zoning_element)
- `inherit_validity` on 3 tables (spatial_plan, planned_space, zoning_element)
- `validate_*_geom` on 7 tables
- `validate_*_topology` on 3 tables (spatial_plan, planned_space, zoning_element)

**Disables 16 geometry relations triggers** (kept for potential QGIS manual drawing re-activation):
- `delete_geom_relations` on 7 tables
- `geom_relations` on 7 tables
- `create_or_update_spatial_plan` on 2 tables (spatial_plan_main, spatial_plan)

**Preserved (not touched):**
- `spatial_plan_validity_time`
- `upsert_creator_and_modifier_trigger`
- Kaavakohde-to-boundary link trigger
- All shared trigger functions

## Rationale

Plan data (dates, lifecycle states) now comes from Ryhti GeoJSON rather than being managed by database triggers. Geometry relations triggers are only disabled (not dropped) so they can be re-enabled with `ALTER TABLE ... ENABLE TRIGGER` when QGIS manual drawing is used.

## Testing

- Build verified (`dotnet build Kauko.DbUp/Kauko.DbUp.csproj` passes)
- Script uses `DROP TRIGGER IF EXISTS` for idempotent execution
- `DISABLE TRIGGER` is naturally idempotent on already-disabled triggers
- Integration testing against a local PostgreSQL instance recommended before deploying
